### PR TITLE
serialdevicewatcher: Do call QSerialPortInfo::availablePorts on each …

### DIFF
--- a/src/serialdevicewatcher.cpp
+++ b/src/serialdevicewatcher.cpp
@@ -1,4 +1,5 @@
 #include <QSerialPortInfo>
+#include <QDir>
 #include "serialdevicewatcher.h"
 
 namespace vfFiles {
@@ -22,20 +23,28 @@ bool SerialDeviceWatcher::create(VfCpp::veinmoduleentity *entity, const QString 
 
 void SerialDeviceWatcher::onTimer()
 {
-    QList<QSerialPortInfo> portInfos = QSerialPortInfo ::availablePorts();
-    QJsonObject json;
-    for(auto portInfo : portInfos) {
-        QString portName = portInfo.portName();
-        if(portName.contains("ttyUSB")) {
-            QJsonObject jsonEntry;
-            jsonEntry.insert("description", portInfo.description());
-            jsonEntry.insert("manufacturer", portInfo.manufacturer());
-            jsonEntry.insert("serial", portInfo.serialNumber());
-            QString systemLocation = portInfo.systemLocation();
-            json.insert(systemLocation, jsonEntry);
+    // Performance measurements showed that QSerialPortInfo::availablePorts()
+    // take ages and slows down system. So try /dev/ttyUSB* first
+    QDir ttySysClassDir(QStringLiteral("/sys/class/tty"));
+    ttySysClassDir.setNameFilters(QStringList("ttyUSB*"));
+    const QFileInfoList fileInfos = ttySysClassDir.entryInfoList();
+    if(fileInfos != m_LastUSBSerialDevsFound) {
+        QJsonObject json;
+        m_LastUSBSerialDevsFound = fileInfos;
+        QList<QSerialPortInfo> portInfos = QSerialPortInfo::availablePorts();
+        for(auto portInfo : portInfos) {
+            QString portName = portInfo.portName();
+            if(portName.contains("ttyUSB")) {
+                QJsonObject jsonEntry;
+                jsonEntry.insert("description", portInfo.description());
+                jsonEntry.insert("manufacturer", portInfo.manufacturer());
+                jsonEntry.insert("serial", portInfo.serialNumber());
+                QString systemLocation = portInfo.systemLocation();
+                json.insert(systemLocation, jsonEntry);
+            }
         }
+        m_veinComponent->setValue(json);
     }
-    m_veinComponent->setValue(json);
 }
 
 }// namespace

--- a/src/serialdevicewatcher.h
+++ b/src/serialdevicewatcher.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QTimer>
 #include <QJsonObject>
+#include <QFileInfoList>
 #include <vf-cpp-entity.h>
 #include <vf-cpp-component.h>
 
@@ -24,7 +25,7 @@ private:
 
     cVeinModuleComponent::Ptr m_veinComponent = nullptr;
     QTimer m_periodicPollTimer;
-
+    QFileInfoList m_LastUSBSerialDevsFound;
 };
 
 }// namespace


### PR DESCRIPTION
…poll

QSerialPortInfo::availablePorts causes huge delays

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>