### PR TITLE
fileaccesscontrol: changes constructor to take Qvector of QDir reference

### DIFF
--- a/file-access-control/src/fileaccesscontrol.cpp
+++ b/file-access-control/src/fileaccesscontrol.cpp
@@ -1,7 +1,8 @@
 #include <QFileInfo>
 #include "fileaccesscontrol.h"
 
-FileAccessControl::FileAccessControl()
+FileAccessControl::FileAccessControl(QVector<QDir> &allowdList) :
+    m_allowedDirs(allowdList)
 {
 
 }

--- a/file-access-control/src/fileaccesscontrol.h
+++ b/file-access-control/src/fileaccesscontrol.h
@@ -7,7 +7,7 @@
 class FileAccessControl
 {
 public:
-    FileAccessControl();
+    FileAccessControl(QVector<QDir> &allowdList);
 
     bool isFileAccessAllowed(QString fileName);
     bool isFolderAccessAllowed(QString folderName);

--- a/file-access-control/tests/gtest/unittest-fileaccesscontrol.cpp
+++ b/file-access-control/tests/gtest/unittest-fileaccesscontrol.cpp
@@ -19,96 +19,106 @@ static const QString nastyTestFolderWithAccess =  QStringLiteral(TEST_DATA_PATH)
 
 TEST(FILE_ACCESS, FILE_FROM_ACCESS_ALLOWED_FOLDER)
 {
-    FileAccessControl testAccess;
-    testAccess.addDirToAllowedDirList(accessAllowedFolder);
+    QVector<QDir> lokalDirVector{accessAllowedFolder};
+    FileAccessControl testAccess(lokalDirVector);
     EXPECT_TRUE(testAccess.isFileAccessAllowed(accessAllowedFile));
 }
 
 TEST(FILE_ACCESS, FILE_FROM_ACCESS_NOT_ALLOWED_FOLDER)
 {
-    FileAccessControl testAccess;
-    testAccess.addDirToAllowedDirList(accessAllowedFolder);
+    QVector<QDir> lokalDirVector{accessAllowedFolder};
+    FileAccessControl testAccess(lokalDirVector);
     EXPECT_FALSE(testAccess.isFileAccessAllowed(accessNotAllowedFile));
 }
 
 TEST(FILE_ACCESS, NON_EXISTING_FILE)
 {
-    FileAccessControl testAccess;
-    testAccess.addDirToAllowedDirList(accessAllowedFolder);
+    QVector<QDir> lokalDirVector{accessAllowedFolder};
+    FileAccessControl testAccess(lokalDirVector);
     EXPECT_FALSE(testAccess.isFileAccessAllowed(nonExistingFile));
 }
 
 TEST(FILE_ACCESS, EMPTY_ACCESS_ALLOWED_LIST)
 {
-    FileAccessControl testAccess;
+    QVector<QDir> lokalDirVector;
+    FileAccessControl testAccess(lokalDirVector);
     EXPECT_FALSE(testAccess.isFileAccessAllowed(accessAllowedFile));
 }
 
 TEST (FILE_ACCESS, FILE_FROM_ACCESS_ALLOWED_SUBFOLDER)
 {
-    FileAccessControl testAccess;
-    testAccess.addDirToAllowedDirList(accessAllowedFolder);
+    QVector<QDir> lokalDirVector{accessAllowedFolder};
+    FileAccessControl testAccess(lokalDirVector);
     EXPECT_TRUE(testAccess.isFileAccessAllowed(accessAllowedSubfolderFile));
 }
 
 TEST (FILE_ACCESS, FILE_FROM_ACCESS_NOT_ALLOWED_SUBFOLDER)
 {
-    FileAccessControl testAccess;
-    testAccess.addDirToAllowedDirList(accessAllowedFolder);
+    QVector<QDir> lokalDirVector{accessAllowedFolder};
+    FileAccessControl testAccess(lokalDirVector);
     EXPECT_FALSE(testAccess.isFileAccessAllowed(accessNotAllowedSubfolderFile));
 }
 
 TEST (FILE_ACCESS, NON_EXISTING_FILE_FROM_ACCESS_ALLOWED_SUBFOLDER)
 {
-    FileAccessControl testAccess;
+    QVector<QDir> lokalDirVector;
+    FileAccessControl testAccess(lokalDirVector);
     testAccess.addDirToAllowedDirList(accessAllowedFolder);
     EXPECT_FALSE(testAccess.isFileAccessAllowed(nonExistingFileAllowedSubfolder));
 }
 
 TEST (FILE_ACCESS, NON_EXISTING_FILE_FROM_ACCESS_NOT_ALLOWED_SUBFOLDER)
 {
-    FileAccessControl testAccess;
+    QVector<QDir> lokalDirVector;
+    FileAccessControl testAccess(lokalDirVector);
     testAccess.addDirToAllowedDirList(accessAllowedFolder);
     EXPECT_FALSE(testAccess.isFileAccessAllowed(nonExistingFileNotAllowedSubfolder));
 }
 
 TEST (FOLDER_ACCESS, ACCESS_ALLOWED_SUBFOLDER )
 {
-    FileAccessControl testAccess;
+    QVector<QDir> lokalDirVector;
+    FileAccessControl testAccess(lokalDirVector);
     testAccess.addDirToAllowedDirList(accessAllowedFolder);
     EXPECT_TRUE(testAccess.isFolderAccessAllowed(accessAllowedSubFolder));
 }
 
 TEST (FOLDER_ACCESS, ACCESS_NOT_ALLOWED_SUBFOLDER )
 {
-    FileAccessControl testAccess;
+    QVector<QDir> lokalDirVector;
+    FileAccessControl testAccess(lokalDirVector);
+
     testAccess.addDirToAllowedDirList(accessAllowedFolder);
     EXPECT_FALSE(testAccess.isFolderAccessAllowed(accessNotAllowedSubFolder));
 }
 
 TEST(FOLDER_ACCESS, NON_EXISTING_FOLDER)
 {
-    FileAccessControl testAccess;
+    QVector<QDir> lokalDirVector;
+    FileAccessControl testAccess(lokalDirVector);
     testAccess.addDirToAllowedDirList(accessAllowedFolder);
     EXPECT_FALSE(testAccess.isFolderAccessAllowed(nonExistingFolder));
 }
 
 TEST(FOLDER_ACCESS, EMPTY_ACCESS_ALLOWED_LIST)
 {
-    FileAccessControl testAccess;
+    QVector<QDir> lokalDirVector;
+    FileAccessControl testAccess(lokalDirVector);
     EXPECT_FALSE(testAccess.isFolderAccessAllowed(accessAllowedFolder));
 }
 
 TEST (FOLDER_ACCESS, NASTY_TEST_FOLDER_WITH_ACCESS )
 {
-    FileAccessControl testAccess;
+    QVector<QDir> lokalDirVector;
+    FileAccessControl testAccess(lokalDirVector);
     testAccess.addDirToAllowedDirList(accessAllowedFolder);
     EXPECT_TRUE(testAccess.isFolderAccessAllowed(nastyTestFolderWithAccess));
 }
 
 TEST (FOLDER_ACCESS, NASTY_TEST_FOLDER_WITH_NO_ACCESS )
 {
-    FileAccessControl testAccess;
+    QVector<QDir> lokalDirVector;
+    FileAccessControl testAccess(lokalDirVector);
     testAccess.addDirToAllowedDirList(accessAllowedFolder);
     EXPECT_FALSE(testAccess.isFolderAccessAllowed(nastyTestFolderWithNoAccess));
 }


### PR DESCRIPTION
Signed-off-by: Wilfried Schunk <w.schunk@zera.de>