### PR TITLE
Fix clazy warnings - sorry for being a nitpicker

### DIFF
--- a/tests/gtest/unittest-fileaccesscontrol.cpp
+++ b/tests/gtest/unittest-fileaccesscontrol.cpp
@@ -2,20 +2,20 @@
 #include <QString>
 #include "fileaccesscontrol.h"
 
-static const QString accessAllowedFile = QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/allowed-folder/access-allowed.txt");
-static const QString accessNotAllowedFile = QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/denied-folder/access-not-allowed.txt");
-static const QString nonExistingFile = QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/allowed-folder/foo.txt");
-static const QString accessAllowedSubfolderFile = QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/allowed-folder/subfolder/subfolder-access-allowed.txt");
-static const QString accessNotAllowedSubfolderFile = QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/denied-folder/subfolder/subfolder-access-not-allowed.txt");
-static const QString nonExistingFileAllowedSubfolder = QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/allowed-folder/subfolder/foo.txt");
-static const QString nonExistingFileNotAllowedSubfolder = QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/denied-folder/subfolder/foo.txt");
+static const char* accessAllowedFile = TEST_DATA_PATH "/allowed-folder/access-allowed.txt";
+static const char* accessNotAllowedFile = TEST_DATA_PATH "/denied-folder/access-not-allowed.txt";
+static const char* nonExistingFile = TEST_DATA_PATH "/allowed-folder/foo.txt";
+static const char* accessAllowedSubfolderFile = TEST_DATA_PATH "/allowed-folder/subfolder/subfolder-access-allowed.txt";
+static const char* accessNotAllowedSubfolderFile = TEST_DATA_PATH "/denied-folder/subfolder/subfolder-access-not-allowed.txt";
+static const char* nonExistingFileAllowedSubfolder = TEST_DATA_PATH "/allowed-folder/subfolder/foo.txt";
+static const char* nonExistingFileNotAllowedSubfolder = TEST_DATA_PATH "/denied-folder/subfolder/foo.txt";
 
-static const QString accessAllowedFolder =  QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/allowed-folder/");
-static const QString accessAllowedSubFolder = QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/allowed-folder/subfolder");
-static const QString accessNotAllowedSubFolder = QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/denied-folder/subfolder");
-static const QString nonExistingFolder =  QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/foo/");
-static const QString nastyTestFolderWithNoAccess =  QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/allowed-folder/../denied-folder");
-static const QString nastyTestFolderWithAccess =  QStringLiteral(TEST_DATA_PATH) + QStringLiteral("/denied-folder/../allowed-folder");
+static const char* accessAllowedFolder =  TEST_DATA_PATH "/allowed-folder/";
+static const char* accessAllowedSubFolder = TEST_DATA_PATH "/allowed-folder/subfolder";
+static const char* accessNotAllowedSubFolder = TEST_DATA_PATH "/denied-folder/subfolder";
+static const char* nonExistingFolder =  TEST_DATA_PATH "/foo/";
+static const char* nastyTestFolderWithNoAccess =  TEST_DATA_PATH "/allowed-folder/../denied-folder";
+static const char* nastyTestFolderWithAccess =  TEST_DATA_PATH "/denied-folder/../allowed-folder";
 
 TEST(FILE_ACCESS, FILE_FROM_ACCESS_ALLOWED_FOLDER)
 {


### PR DESCRIPTION
Fix all warnings as:
| vf-files/tests/gtest/unittest-fileaccesscontrol.cpp:4:1: non-POD static (QString) [clazy-non-pod-global-static]

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>