### PR TITLE
fileaccesscontrol: allows not existing files and folders to be accessed

### DIFF
--- a/src/fileaccesscontrol.cpp
+++ b/src/fileaccesscontrol.cpp
@@ -17,12 +17,7 @@ bool FileAccessControl::isFileAccessAllowed(QString fileName)
 {
     QFileInfo fileInfo(fileName);
 
-    if (fileInfo.exists()) {
-        return isFolderAccessAllowed(fileInfo.absolutePath());
-    }
-    else {
-        return false;
-    }
+    return isFolderAccessAllowed(fileInfo.absolutePath());
 }
 
 bool FileAccessControl::isFolderAccessAllowed(QString folderName)
@@ -30,11 +25,9 @@ bool FileAccessControl::isFolderAccessAllowed(QString folderName)
     QDir dir(folderName);
     bool accessAllowed = false;
 
-    if (dir.exists()) {
+    accessAllowed = m_allowedDirs.contains(dir);
+    while (!accessAllowed && dir.cdUp()) {
         accessAllowed = m_allowedDirs.contains(dir);
-        while (!accessAllowed && dir.cdUp()) {
-            accessAllowed = m_allowedDirs.contains(dir);
-        }
     }
 
     return accessAllowed;

--- a/src/vf_files.cpp
+++ b/src/vf_files.cpp
@@ -79,23 +79,22 @@ QVariant vf_files::RPC_CopyFile(QVariantMap p_params)
     bool bSourceExists = QFile::exists(sourceFile);
     bool bDestExists = QFile::exists(destFile);
 
+    if (!m_fileAccessController->isFileAccessAllowed(sourceFile)) {
+            appendErrorMsg(strError, QStringLiteral("RPC_CopyFile: ") + sourceFile + QStringLiteral(" access denied"));
+    }
+
+    if (!m_fileAccessController->isFileAccessAllowed(destFile)) {
+            appendErrorMsg(strError, QStringLiteral("RPC_CopyFile: ") + destFile + QStringLiteral(" access denied"));
+    }
+
     // check some obvious plausis first
     if(!bSourceExists) {
          appendErrorMsg(strError, QStringLiteral("RPC_CopyFile: ") + sourceFile + QStringLiteral(" does not exist"));
      }
-    else if (!m_fileAccessController->isFileAccessAllowed(sourceFile)) {
-        appendErrorMsg(strError, QStringLiteral("RPC_CopyFile: ") + sourceFile + QStringLiteral(" access denied"));
-    }
 
      if(!p_overwrite && bDestExists) {
          appendErrorMsg(strError, QStringLiteral("RPC_CopyFile: Cannot overwrite ") + destFile);
      }
-    else {
-        QString folderName = destFile.left(destFile.lastIndexOf(QDir::separator()));
-         if (!m_fileAccessController->isFolderAccessAllowed(folderName)) {
-        appendErrorMsg(strError, QStringLiteral("RPC_CopyFile: ") + folderName + QStringLiteral(" access denied"));
-         }
-    }
 
     // ensure dest directory is there
     if(strError.isEmpty()) {

--- a/tests/gtest/unittest-fileaccesscontrol.cpp
+++ b/tests/gtest/unittest-fileaccesscontrol.cpp
@@ -4,7 +4,8 @@
 
 static const char* accessAllowedFile = TEST_DATA_PATH "/allowed-folder/access-allowed.txt";
 static const char* accessNotAllowedFile = TEST_DATA_PATH "/denied-folder/access-not-allowed.txt";
-static const char* nonExistingFile = TEST_DATA_PATH "/allowed-folder/foo.txt";
+static const char* nonExistingFileInAllowedFolder = TEST_DATA_PATH "/allowed-folder/foo.txt";
+static const char* nonExistingFileNotInAllowedFolder = TEST_DATA_PATH "/denied-folder/foo.txt";
 static const char* accessAllowedSubfolderFile = TEST_DATA_PATH "/allowed-folder/subfolder/subfolder-access-allowed.txt";
 static const char* accessNotAllowedSubfolderFile = TEST_DATA_PATH "/denied-folder/subfolder/subfolder-access-not-allowed.txt";
 static const char* nonExistingFileAllowedSubfolder = TEST_DATA_PATH "/allowed-folder/subfolder/foo.txt";
@@ -14,8 +15,11 @@ static const char* accessAllowedFolder =  TEST_DATA_PATH "/allowed-folder/";
 static const char* accessAllowedSubFolder = TEST_DATA_PATH "/allowed-folder/subfolder";
 static const char* accessNotAllowedSubFolder = TEST_DATA_PATH "/denied-folder/subfolder";
 static const char* nonExistingFolder =  TEST_DATA_PATH "/foo/";
+static const char* nonExistingFolderInAllowedList =  TEST_DATA_PATH "/allowed-folder/subfolder/foo";
+static const char* nonExistingFolderNotInAllowedList =  TEST_DATA_PATH "/denied-folder/subfolder/foo";
 static const char* nastyTestFolderWithNoAccess =  TEST_DATA_PATH "/allowed-folder/../denied-folder";
 static const char* nastyTestFolderWithAccess =  TEST_DATA_PATH "/denied-folder/../allowed-folder";
+
 
 TEST(FILE_ACCESS, FILE_FROM_ACCESS_ALLOWED_FOLDER)
 {
@@ -31,11 +35,18 @@ TEST(FILE_ACCESS, FILE_FROM_ACCESS_NOT_ALLOWED_FOLDER)
     EXPECT_FALSE(testAccess.isFileAccessAllowed(accessNotAllowedFile));
 }
 
-TEST(FILE_ACCESS, NON_EXISTING_FILE)
+TEST(FILE_ACCESS, NON_EXISTING_FILE_IN_ALLOWED_FOLDER_LIST)
 {
     QStringList allowedFolders{accessAllowedFolder};
     FileAccessControl testAccess(allowedFolders);
-    EXPECT_FALSE(testAccess.isFileAccessAllowed(nonExistingFile));
+    EXPECT_TRUE(testAccess.isFileAccessAllowed(nonExistingFileInAllowedFolder));
+}
+
+TEST(FILE_ACCESS, NON_EXISTING_FILE_NOT_IN_ALLOWED_FOLDER_LIST)
+{
+    QStringList allowedFolders{accessAllowedFolder};
+    FileAccessControl testAccess(allowedFolders);
+    EXPECT_FALSE(testAccess.isFileAccessAllowed(nonExistingFileNotInAllowedFolder));
 }
 
 TEST(FILE_ACCESS, EMPTY_ACCESS_ALLOWED_LIST)
@@ -64,7 +75,7 @@ TEST (FILE_ACCESS, NON_EXISTING_FILE_FROM_ACCESS_ALLOWED_SUBFOLDER)
     QStringList allowedFolders;
     FileAccessControl testAccess(allowedFolders);
     testAccess.addDirToAllowedDirList(accessAllowedFolder);
-    EXPECT_FALSE(testAccess.isFileAccessAllowed(nonExistingFileAllowedSubfolder));
+    EXPECT_TRUE(testAccess.isFileAccessAllowed(nonExistingFileAllowedSubfolder));
 }
 
 TEST (FILE_ACCESS, NON_EXISTING_FILE_FROM_ACCESS_NOT_ALLOWED_SUBFOLDER)
@@ -97,6 +108,15 @@ TEST(FOLDER_ACCESS, NON_EXISTING_FOLDER)
     FileAccessControl testAccess(allowedFolders);
     testAccess.addDirToAllowedDirList(accessAllowedFolder);
     EXPECT_FALSE(testAccess.isFolderAccessAllowed(nonExistingFolder));
+    EXPECT_FALSE(testAccess.isFolderAccessAllowed(nonExistingFolderNotInAllowedList));
+}
+
+TEST(FOLDER_ACCESS, NON_EXISTING_FOLDER_IN_ALLOWED_LIST)
+{
+    QStringList allowedFolders;
+    FileAccessControl testAccess(allowedFolders);
+    testAccess.addDirToAllowedDirList(accessAllowedFolder);
+    EXPECT_TRUE(testAccess.isFolderAccessAllowed(nonExistingFolderInAllowedList));
 }
 
 TEST(FOLDER_ACCESS, EMPTY_ACCESS_ALLOWED_LIST)


### PR DESCRIPTION
even not existing files and folders can be accessed when they are in the allowedlist, mandatory for new usb drives

Signed-off-by: Wilfried Schunk <w.schunk@zera.de>