### PR TITLE
fileaccesscontrol: Use string operations to move one folder up

### DIFF
--- a/src/fileaccesscontrol.cpp
+++ b/src/fileaccesscontrol.cpp
@@ -22,12 +22,15 @@ bool FileAccessControl::isFileAccessAllowed(QString fileName)
 
 bool FileAccessControl::isFolderAccessAllowed(QString folderName)
 {
-    QDir dir(folderName);
     bool accessAllowed = false;
+    QString folderPath = folderName;
 
-    accessAllowed = m_allowedDirs.contains(dir);
-    while (!accessAllowed && dir.cdUp()) {
-        accessAllowed = m_allowedDirs.contains(dir);
+    //deny access to all folder paths which contain '..'
+    if (!folderPath.contains("..")) {
+        while (!accessAllowed && !folderPath.isEmpty()) {
+            accessAllowed = m_allowedDirs.contains(folderPath);
+            folderPath = folderPath.left(folderPath.lastIndexOf(QDir::separator()));
+        }
     }
 
     return accessAllowed;

--- a/tests/gtest/unittest-fileaccesscontrol.cpp
+++ b/tests/gtest/unittest-fileaccesscontrol.cpp
@@ -131,7 +131,7 @@ TEST (FOLDER_ACCESS, NASTY_TEST_FOLDER_WITH_ACCESS )
     QStringList allowedFolders;
     FileAccessControl testAccess(allowedFolders);
     testAccess.addDirToAllowedDirList(accessAllowedFolder);
-    EXPECT_TRUE(testAccess.isFolderAccessAllowed(nastyTestFolderWithAccess));
+    EXPECT_FALSE(testAccess.isFolderAccessAllowed(nastyTestFolderWithAccess));
 }
 
 TEST (FOLDER_ACCESS, NASTY_TEST_FOLDER_WITH_NO_ACCESS )


### PR DESCRIPTION
cdUp() from QDir checks if that folder exists and we don't want that.

Signed-off-by: Anuja Mutalik <a.mutalik@zera.de>