### PR TITLE
DefaultPathEntry: Do not keep shared poiner to component

### DIFF
--- a/src/defaultpathentry.cpp
+++ b/src/defaultpathentry.cpp
@@ -20,7 +20,7 @@ bool DefaultPathEntry::create(VfCpp::VfCppEntity *entity, const QString componen
         if(!setPath.endsWith(QDir::separator())) {
             setPath.append(QDir::separator());
         }
-        m_veinComponent = entity->createComponent(componentName, setPath, true);
+        entity->createComponent(componentName, setPath, true);
     }
     return ok;
 }

--- a/src/defaultpathentry.h
+++ b/src/defaultpathentry.h
@@ -14,10 +14,6 @@ public:
                 const QString componentName,
                 const QString path,
                 const bool create);
-
-private:
-    VfCpp::VeinCompProxy<QStringList> m_veinComponent;
-
 };
 
 #endif // DEFAULTPATHENTRY_H


### PR DESCRIPTION
* DefaultPathEntry is a const so set value once only and then not accessed
* VfCppEntity keeps component alive by keeping in a container object